### PR TITLE
Updated to 3.0.0-rc1

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/OpenAPIDeserializer.java
@@ -78,6 +78,11 @@ public class OpenAPIDeserializer {
 
             // required
             String value = getString("openapi", on, true, location, result);
+
+            // we don't even try if the version isn't there
+            if(value == null || !value.startsWith("3.0")) {
+                return null;
+            }
             openAPI.setOpenapi(value);
 
             ObjectNode obj = getObject("info", on, true, "", result);

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
@@ -13,7 +13,7 @@ public class OpenAPIParserTest {
 
         assertNotNull(result);
         assertNotNull(result.getOpenAPI());
-        assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-rc0");
+        assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-rc1");
     }
 
     @Test
@@ -24,14 +24,14 @@ public class OpenAPIParserTest {
 
         assertNotNull(result);
         assertNotNull(result.getOpenAPI());
-        assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-rc0");
+        assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-rc1");
     }
 
     @Test
     public void test30() {
         String yaml =
             "{\n" +
-            "  \"openapi\": \"3.0.0-rc0\",\n" +
+            "  \"openapi\": \"3.0.0-rc1\",\n" +
             "  \"info\": {\n" +
             "    \"title\": \"Swagger Petstore\",\n" +
             "    \"description\": \"This is a sample server Petstore server. You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/). For this sample, you can use the api key `special-key` to test the authorization filters.\",\n" +
@@ -51,6 +51,6 @@ public class OpenAPIParserTest {
 
         assertNotNull(result);
         assertNotNull(result.getOpenAPI());
-        assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-rc0");
+        assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-rc1");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Small changes needed for supporting the 3.0.0-rc1 models, which live here:

https://github.com/swagger-api/swagger-core/tree/feature/3.0.0-rc1